### PR TITLE
Guard admin mutation routes and add regression tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+client/dist-tests/

--- a/client/__tests__/admin-guard.test.ts
+++ b/client/__tests__/admin-guard.test.ts
@@ -1,0 +1,127 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import path from 'node:path';
+
+type EndpointCase = {
+  name: string;
+  file: string;
+  body: Record<string, any>;
+};
+
+type MockResponse = {
+  statusCode: number;
+  body?: any;
+  status: (code: number) => MockResponse;
+  json: (payload: any) => MockResponse;
+  end: () => MockResponse;
+};
+
+const endpoints: EndpointCase[] = [
+  {
+    name: 'admin-add-ton',
+    file: 'admin-add-ton',
+    body: { user_id: 'user-1', amount_ton: 1 },
+  },
+  {
+    name: 'admin-bonus',
+    file: 'admin-bonus',
+    body: { user_id: 'user-1', amount_rub: 100 },
+  },
+  {
+    name: 'admin-ban',
+    file: 'admin-ban',
+    body: { user_id: 'user-1', reason: 'test' },
+  },
+  {
+    name: 'admin-confirm',
+    file: 'admin-confirm',
+    body: { request_id: 'req-1', paid_amount_rub: 100 },
+  },
+  {
+    name: 'admin-reject',
+    file: 'admin-reject',
+    body: { request_id: 'req-1' },
+  },
+  {
+    name: 'admin-set-limit',
+    file: 'admin-set-limit',
+    body: { user_id: 'user-1', wallet_limit: 100 },
+  },
+  {
+    name: 'admin-unban',
+    file: 'admin-unban',
+    body: { user_id: 'user-1' },
+  },
+];
+
+function createMockRes(): MockResponse & { body?: any } {
+  const res: Partial<MockResponse & { body?: any }> = {
+    statusCode: 200,
+  };
+  res.status = (code: number) => {
+    res.statusCode = code;
+    return res as MockResponse;
+  };
+  res.json = (payload: any) => {
+    res.body = payload;
+    return res as MockResponse;
+  };
+  res.end = () => res as MockResponse;
+  return res as MockResponse & { body?: any };
+}
+
+for (const endpoint of endpoints) {
+  test(`rejects unauthenticated access to ${endpoint.name}`, async () => {
+    const guardPath = path.join(__dirname, '..', 'pages', 'api', 'admin', '_guard.js');
+    let guardCalls = 0;
+    require.cache[guardPath] = {
+      id: guardPath,
+      filename: guardPath,
+      loaded: true,
+      exports: {
+        requireAdmin: async (_req: unknown, res: MockResponse) => {
+          guardCalls += 1;
+          res.status(401).json({ error: 'FORBIDDEN' });
+          return null;
+        },
+      },
+    } as any;
+
+    const supabasePath = require.resolve('@supabase/supabase-js');
+    const originalSupabaseCache = require.cache[supabasePath];
+    const supabaseExports = originalSupabaseCache?.exports ?? require(supabasePath);
+    const createClientCalls: number[] = [];
+    require.cache[supabasePath] = {
+      id: supabasePath,
+      filename: supabasePath,
+      loaded: true,
+      exports: {
+        ...supabaseExports,
+        createClient: (..._args: any[]) => {
+          createClientCalls.push(1);
+          return {};
+        },
+      },
+    } as any;
+
+    const handlerPath = path.join(__dirname, '..', 'pages', 'api', `${endpoint.file}.js`);
+    delete require.cache[handlerPath];
+    const handlerModule = require(handlerPath);
+    const handler = handlerModule.default ?? handlerModule;
+
+    const res = createMockRes();
+    await handler({ method: 'POST', body: endpoint.body }, res);
+
+    assert.equal(guardCalls, 1);
+    assert.ok(res.statusCode === 401 || res.statusCode === 403);
+    assert.ok(res.body && typeof res.body.error === 'string');
+    assert.equal(createClientCalls.length, 0);
+
+    delete require.cache[guardPath];
+    if (originalSupabaseCache) {
+      require.cache[supabasePath] = originalSupabaseCache;
+    } else {
+      delete require.cache[supabasePath];
+    }
+  });
+}

--- a/client/package.json
+++ b/client/package.json
@@ -5,7 +5,9 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start"
+    "start": "next start",
+    "test": "npm run test:build && node --test dist-tests/__tests__/admin-guard.test.js",
+    "test:build": "tsc --project tsconfig.test.json"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.39.3",

--- a/client/pages/api/admin-add-ton.ts
+++ b/client/pages/api/admin-add-ton.ts
@@ -1,4 +1,5 @@
 import { createClient } from '@supabase/supabase-js';
+import { requireAdmin } from './admin/_guard';
 
 /**
  * API route for administrators to manually credit TON to a user's balance.
@@ -7,6 +8,9 @@ import { createClient } from '@supabase/supabase-js';
  */
 export default async function handler(req: any, res: any) {
   if (req.method !== 'POST') return res.status(405).end();
+  const admin = await requireAdmin(req, res);
+  if (!admin) return;
+
   const supabase = createClient(process.env.SUPABASE_URL!, process.env.SUPABASE_SERVICE_KEY!);
   const { user_id, amount_ton } = req.body || {};
   if (!user_id || !amount_ton) return res.status(400).json({ error: 'user_id and amount_ton are required' });

--- a/client/pages/api/admin-ban.ts
+++ b/client/pages/api/admin-ban.ts
@@ -1,7 +1,11 @@
 import { createClient } from '@supabase/supabase-js';
+import { requireAdmin } from './admin/_guard';
 export default async function handler(req, res) {
   // Only allow POST requests
   if (req.method !== 'POST') return res.status(405).end();
+  const admin = await requireAdmin(req, res);
+  if (!admin) return;
+
   const supabase = createClient(process.env.SUPABASE_URL!, process.env.SUPABASE_SERVICE_KEY!);
   const { user_id, reason } = req.body || {};
   if (!user_id) return res.status(400).json({ error: 'user_id is required' });

--- a/client/pages/api/admin-bonus.ts
+++ b/client/pages/api/admin-bonus.ts
@@ -1,6 +1,11 @@
 import { createClient } from '@supabase/supabase-js';
+import { requireAdmin } from './admin/_guard';
+
 export default async function handler(req, res){
   if(req.method!=='POST') return res.status(405).end();
+  const admin = await requireAdmin(req, res);
+  if(!admin) return;
+
   const supabase = createClient(process.env.SUPABASE_URL!, process.env.SUPABASE_SERVICE_KEY!);
   const { user_id, amount_rub } = req.body;
   const { error } = await supabase.rpc('grant_bonus_balance', { p_user_id: user_id, p_amount: amount_rub });

--- a/client/pages/api/admin-confirm.ts
+++ b/client/pages/api/admin-confirm.ts
@@ -1,21 +1,25 @@
 import { createClient } from '@supabase/supabase-js';
 import { notifyUser } from './_notify';
+import { requireAdmin } from './admin/_guard';
 
 export default async function handler(req, res){
   if(req.method!=='POST') return res.status(405).end();
+  const admin = await requireAdmin(req, res);
+  if(!admin) return;
+
   const supabase = createClient(process.env.SUPABASE_URL!, process.env.SUPABASE_SERVICE_KEY!);
-  const { request_id, paid_amount_rub, admin_id } = req.body;
+  const { request_id, paid_amount_rub } = req.body;
   const { data, error } = await supabase.from('payment_requests')
-    .update({ status:'paid', paid_amount_rub, admin_id, paid_at:new Date() })
+    .update({ status:'paid', paid_amount_rub, admin_id: admin.tg_id ?? null, paid_at:new Date() })
     .eq('id', request_id).select();
   if(error) return res.status(400).json({ error });
   const reqRow = data[0];
   await supabase.rpc('debit_user_balance', { p_user_id: reqRow.user_id, p_amount: paid_amount_rub });
   // fetch user to notify
-const { data: userRow } = await supabase.from('users').select('tg_id').eq('id', reqRow.user_id).single();
-if (userRow?.tg_id) {
-  await notifyUser(String(userRow.tg_id), `✅ Оплата подтверждена на сумму ${paid_amount_rub} ₽`);
-}
+  const { data: userRow } = await supabase.from('users').select('tg_id').eq('id', reqRow.user_id).single();
+  if (userRow?.tg_id) {
+    await notifyUser(String(userRow.tg_id), `✅ Оплата подтверждена на сумму ${paid_amount_rub} ₽`);
+  }
 
   res.json({ success:true, request:reqRow });
 }

--- a/client/pages/api/admin-reject.ts
+++ b/client/pages/api/admin-reject.ts
@@ -1,12 +1,16 @@
 import { createClient } from '@supabase/supabase-js';
 import { notifyUser } from './_notify';
+import { requireAdmin } from './admin/_guard';
 
 export default async function handler(req, res){
   if(req.method!=='POST') return res.status(405).end();
+  const admin = await requireAdmin(req, res);
+  if(!admin) return;
+
   const supabase = createClient(process.env.SUPABASE_URL!, process.env.SUPABASE_SERVICE_KEY!);
-  const { request_id, admin_id } = req.body;
+  const { request_id } = req.body;
   const { data, error } = await supabase.from('payment_requests')
-    .update({ status:'rejected', admin_id })
+    .update({ status:'rejected', admin_id: admin.tg_id ?? null })
     .eq('id', request_id).select();
   if(error) return res.status(400).json({ error });
   res.json({ success:true, request:data[0] });

--- a/client/pages/api/admin-set-limit.ts
+++ b/client/pages/api/admin-set-limit.ts
@@ -1,4 +1,5 @@
 import { createClient } from '@supabase/supabase-js';
+import { requireAdmin } from './admin/_guard';
 
 /**
  * API route to update a user's wallet restrictions and limits. Accepts
@@ -8,6 +9,9 @@ import { createClient } from '@supabase/supabase-js';
  */
 export default async function handler(req: any, res: any) {
   if (req.method !== 'POST') return res.status(405).end();
+  const admin = await requireAdmin(req, res);
+  if (!admin) return;
+
   const supabase = createClient(process.env.SUPABASE_URL!, process.env.SUPABASE_SERVICE_KEY!);
   const { user_id, wallet_limit, wallet_restricted } = req.body || {};
   if (!user_id) return res.status(400).json({ error: 'user_id is required' });

--- a/client/pages/api/admin-unban.ts
+++ b/client/pages/api/admin-unban.ts
@@ -1,8 +1,12 @@
 import { createClient } from '@supabase/supabase-js';
+import { requireAdmin } from './admin/_guard';
 
 export default async function handler(req: any, res: any) {
   // Only POST requests are allowed
   if (req.method !== 'POST') return res.status(405).end();
+  const admin = await requireAdmin(req, res);
+  if (!admin) return;
+
   const supabase = createClient(process.env.SUPABASE_URL!, process.env.SUPABASE_SERVICE_KEY!);
   const { user_id } = req.body || {};
   if (!user_id) return res.status(400).json({ error: 'user_id is required' });

--- a/client/tsconfig.test.json
+++ b/client/tsconfig.test.json
@@ -1,0 +1,18 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "outDir": "./dist-tests",
+    "module": "commonjs",
+    "target": "es2019",
+    "types": ["node"],
+    "declaration": false,
+    "sourceMap": false
+  },
+  "include": [
+    "__tests__/**/*.test.ts",
+    "pages/api/**/*.ts",
+    "pages/api/admin/**/*.ts",
+    "lib/**/*.ts"
+  ]
+}


### PR DESCRIPTION
## Summary
- require the shared admin guard in admin mutation API routes before performing any work
- use the authenticated admin context for payment confirmation/rejection metadata
- add Node-based regression tests that ensure unauthorized calls are blocked and ignore generated build output

## Testing
- npm run test --workspace client

------
https://chatgpt.com/codex/tasks/task_b_68da76746970832c9620d9ca25bdd996